### PR TITLE
Add opening time property

### DIFF
--- a/src/components/lisItem.js
+++ b/src/components/lisItem.js
@@ -2,9 +2,11 @@ import { useState, useContext } from 'preact/hooks';
 
 // Actions
 import { Action } from '../index'
+import { ListOpeningtime } from './listOpeningtime';
 
-export const ListItem = ({ name, tel, site, mail, note, newEntry }) => {
+export const ListItem = ({ name, tel, site, mail, note, newEntry, openingtimes }) => {
 	const [infoVisible, setInfoVisible] = useState(false);
+	const [openingtimeVisible, setOpeningtimeVisible] = useState(false);
 	const action = useContext(Action);
 	const encodedName = encodeURIComponent(name);
 	const encodedCity = encodeURIComponent(process.env.PREACT_APP_CITY);
@@ -12,6 +14,9 @@ export const ListItem = ({ name, tel, site, mail, note, newEntry }) => {
 
 	function handleClick() {
 		setInfoVisible(!infoVisible);
+	}
+	function viewOpeningtime() {
+		setOpeningtimeVisible(!openingtimeVisible);
 	}
 
 	return (
@@ -21,6 +26,16 @@ export const ListItem = ({ name, tel, site, mail, note, newEntry }) => {
 					<a class="hover:underline" href={searchUrl} target="_blank" rel="noopener noreferrer">{name}</a>
 				</span>
 				<div class="flex">
+					{openingtimes && (
+						<span
+							onClick={viewOpeningtime}
+							class="inline-block mx-1 md:mx-2 w-8 h-8 cursor-pointer text-center leading-8 bg-red-300 rounded-lg"
+							role="img"
+							aria-label="warning"
+						>
+							🕔
+						</span>
+					)}
 					{note && (
 						<span
 							onClick={handleClick}
@@ -69,6 +84,15 @@ export const ListItem = ({ name, tel, site, mail, note, newEntry }) => {
 			{infoVisible && (
 				<div class="block mt-10">
 					<p class="text-yellow-700 text-sm md:text-md lg:text-lg">{note}</p>
+				</div>
+			)}
+			{openingtimeVisible && (
+				<div class="block mt-10">
+					{
+						openingtimes.map(openingtime => (
+							<ListOpeningtime key={openingtime.days} {...openingtime} />
+						))
+					}
 				</div>
 			)}
 		</div>

--- a/src/components/listOpeningtime.js
+++ b/src/components/listOpeningtime.js
@@ -1,0 +1,5 @@
+export const ListOpeningtime = ({ days = '', times = ''}) => {
+	return (
+        <p class="text-yellow-700 text-sm md:text-md lg:text-lg">{days}: {times}</p>
+	);
+};

--- a/src/routes/form.js
+++ b/src/routes/form.js
@@ -35,6 +35,11 @@ export default function Form() {
 					</label>
 				</p>
 				<p class="my-5">
+					<label class="lock text-gray-800 ml-2 font-bold md:text-right mb-1 md:mb-0 pr-4">Orari di apertura
+						<textarea class="bg-white focus:outline-none focus:shadow-outline border border-gray-500 rounded-lg py-2 px-4 block w-full appearance-none leading-normal" type="text" name="openingtime" />
+					</label>
+				</p>
+				<p class="my-5">
 					<button class="block w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" type="submit">Send</button>
 				</p>
 			</form>


### PR DESCRIPTION
This feature add the opening time property in the shop properties.
In json simply add openingtimes property like in the following example.
```json
"openingtimes": [
    {
         "days": "LUN-MAR",
         "times": "10,00-15,00"
    },
    {
         "days": "MER-GIO",
         "times": "9,00-14,00"
    }
]
```
You can see the result in the following screenshot.
![image](https://user-images.githubusercontent.com/15997606/78928508-032fa980-7aa1-11ea-964a-3dc71a303ac5.png)
This feature adds the textarea for request this property in the form.
